### PR TITLE
fix: Resolve standings API and improve error handling

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -1,0 +1,41 @@
+# NBA Scores Extension - Development Guide
+
+## Commands
+- `npm run build` - Production build (TypeScript check + Vite build)
+- `npm run lint` - ESLint validation (max 0 warnings allowed)
+- `npm run type-check` - TypeScript validation without emitting
+- `npm run dev` - Development server
+- No test framework configured
+
+## Code Style
+
+### Imports & Formatting
+- Use absolute imports with `@/` prefix for src files
+- Group imports: React/external → internal components → types → utils
+- Use `clsx` and `tailwind-merge` for conditional styling
+- Follow shadcn/ui component patterns
+
+### TypeScript
+- Strict mode enabled - all types must be defined
+- Use interfaces for objects, types for unions/primitives
+- Prefix unused params with `_` (ESLint rule)
+- Avoid `any` type (ESLint warns)
+
+### Naming Conventions
+- Components: PascalCase, descriptive names
+- Hooks: `use` prefix (camelCase)
+- Functions/variables: camelCase
+- Constants: UPPER_SNAKE_CASE
+- Files: kebab-case (utils), PascalCase (components)
+
+### Error Handling
+- Use ErrorBoundary for React errors
+- TanStack Query for async state with fallbacks
+- Chrome extension storage with error handling
+- Service layer for API calls with graceful fallbacks
+
+### Architecture
+- Custom hooks for data fetching (TanStack Query)
+- Type-safe interfaces in `/types` directory
+- Component structure: common/ → features/ → ui/
+- Zod schemas for validation

--- a/src/components/scores/GamePreview.tsx
+++ b/src/components/scores/GamePreview.tsx
@@ -113,6 +113,10 @@ const GamePreview: React.FC<GamePreviewProps> = ({ boxScore, isLoading, onClose 
               src={team.logo} 
               alt={team.displayName}
               className="w-10 h-10"
+              onError={(e) => {
+                e.currentTarget.src = '';
+                e.currentTarget.style.display = 'none';
+              }}
             />
             <div>
               <h3 className="font-semibold text-sm">{team.displayName}</h3>
@@ -219,11 +223,15 @@ const GamePreview: React.FC<GamePreviewProps> = ({ boxScore, isLoading, onClose 
           {leaders.map((teamLeader) => (
             <div key={teamLeader.team.id} className="space-y-3">
               <div className="flex items-center gap-2">
-                <img 
-                  src={teamLeader.team.logo} 
-                  alt={teamLeader.team.displayName}
-                  className="w-5 h-5"
-                />
+                 <img 
+                   src={teamLeader.team.logo} 
+                   alt={teamLeader.team.displayName}
+                   className="w-5 h-5"
+                   onError={(e) => {
+                     e.currentTarget.src = '';
+                     e.currentTarget.style.display = 'none';
+                   }}
+                 />
                 <span className="font-medium text-sm">{teamLeader.team.displayName}</span>
               </div>
               <div className="space-y-2">
@@ -236,9 +244,13 @@ const GamePreview: React.FC<GamePreviewProps> = ({ boxScore, isLoading, onClose 
                       {category.leaders.map((leader, idx) => (
                         <div key={idx} className="flex items-center gap-2">
                           <img 
-                            src={leader.athlete.headshot.href} 
+                            src={leader.athlete.headshot?.href || ''} 
                             alt={leader.athlete.displayName}
                             className="w-6 h-6 rounded-full"
+                            onError={(e) => {
+                              e.currentTarget.src = '';
+                              e.currentTarget.style.display = 'none';
+                            }}
                           />
                           <div>
                             <span className="text-xs font-medium">{leader.athlete.displayName}</span>

--- a/src/components/scores/ScoresList.tsx
+++ b/src/components/scores/ScoresList.tsx
@@ -74,8 +74,14 @@ export default function ScoresList() {
   };
 
   const handleGameClick = (gameId: string) => {
-    setSelectedGameId(gameId);
-    openPreview(gameId);
+    try {
+      setSelectedGameId(gameId);
+      openPreview(gameId);
+    } catch (error) {
+      console.error('Failed to open game preview:', error);
+      // Reset selected game ID on error
+      setSelectedGameId(null);
+    }
   };
 
   const handleBackToScores = () => {

--- a/src/hooks/useGamePreview.ts
+++ b/src/hooks/useGamePreview.ts
@@ -13,9 +13,11 @@ export const useGamePreview = () => {
     refetch
   } = useQuery({
     queryKey: ['boxScore', selectedGameId],
-    queryFn: () => selectedGameId ? sportsApi.getBoxScore(selectedGameId) : null,
+    queryFn: () => selectedGameId ? sportsApi.getBoxScore(selectedGameId) : Promise.resolve(null),
     enabled: !!selectedGameId && isPreviewOpen,
     staleTime: 30000, // 30 seconds
+    retry: 2,
+    retryDelay: 1000,
   });
 
   const openPreview = (gameId: string) => {

--- a/src/hooks/useStandings.ts
+++ b/src/hooks/useStandings.ts
@@ -28,7 +28,7 @@ interface TeamStandingWithStats {
 async function fetchConferenceStandings(groupId: number): Promise<TeamStandingWithStats[]> {
   try {
     const coreApiUrl = import.meta.env.VITE_CORE_API_BASE_URL;
-    const standingsResponse = await fetch(`${coreApiUrl}/v2/sports/basketball/leagues/nba/seasons/2025/types/2/groups/${groupId}/standings/0?lang=en&region=us`);
+    const standingsResponse = await fetch(`${coreApiUrl}/seasons/2025/types/2/groups/${groupId}/standings/0?lang=en&region=us`);
     if (!standingsResponse.ok) {
       throw new Error(`Failed to fetch standings for group ${groupId}`);
     }
@@ -173,7 +173,7 @@ async function fetchStandings(): Promise<Standings> {
         const gbStat = team.stats.find((s) => s.name === 'gamesBehind');
         if (gbStat) {
           gbStat.value = gamesBehind;
-          gbStat.displayValue = gamesBehind === 0 ? '-' : gamesBehind.toString();
+          gbStat.displayValue = gamesBehind === 0 ? '-' : gamesBehind % 1 === 0 ? gamesBehind.toString() : gamesBehind.toFixed(1);
         }
 
         return team;


### PR DESCRIPTION
## Summary

- Fix ESPN Core API endpoint for standings data (removed incorrect /v2 prefix)
- Improve games behind calculation to display decimals correctly (0.5 format)  
- Add error handling for broken images in game preview components
- Add try-catch for game preview navigation to prevent crashes
- Improve box score query with Promise.resolve fallback and retry logic
- Add development guide for consistent coding standards