### PR TITLE
fix: Remove dummy URLs from manifest for universal site compatibility

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,10 +6,7 @@
   "permissions": [
     "storage"
   ],
-  "host_permissions": [
-    "https://your-nba-api-endpoint.com/*",
-    "https://your-core-nba-api-endpoint.com/*"
-  ],
+  "host_permissions": [],
   "action": {
     "default_popup": "popup.html",
     "default_title": "NBA Scores",
@@ -27,6 +24,6 @@
     "128": "icons/icon128.png"
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://your-nba-api-endpoint.com https://your-core-nba-api-endpoint.com https://cdn.espn.com https://site.web.api.espn.com https://sports.core.api.espn.com;"
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https:;"
   }
 }


### PR DESCRIPTION
## Summary

- Remove placeholder host_permissions to allow extension on any site
- Simplify CSP to allow any HTTPS endpoint since API URLs are configured via env vars
- Ensure extension works properly in new tabs and all contexts

## Verification

- [ ] Extension loads properly in new tab
- [ ] Extension works on any website
- [ ] API endpoints still function with environment variable configuration
- [ ] CSP still blocks insecure connections while allowing legitimate HTTPS APIs