### PR TITLE
feat: Redesign extension UI with new design token system, refined components, and zoned standings

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -6,16 +6,11 @@
     <title>NBA Scores</title>
     <style>
       body {
-        width: 400px;
+        width: 540px;
         height: 600px;
         margin: 0;
         padding: 0;
         overflow: hidden;
-        background-color: white;
-      }
-
-      body.dark {
-        background-color: #111827;
       }
 
       #root {

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
+import { AlertTriangle } from 'lucide-react';
 
 interface Props {
   children: ReactNode;
@@ -25,16 +26,19 @@ export default class ErrorBoundary extends Component<Props, State> {
   public render() {
     if (this.state.hasError) {
       return (
-        <div className="p-4 text-center">
-          <h2 className="text-lg font-semibold text-red-600 mb-2">
+        <div className="flex h-full flex-col items-center justify-center p-6 text-center">
+          <div className="grid h-12 w-12 place-items-center rounded-full bg-destructive/10 text-destructive">
+            <AlertTriangle className="h-6 w-6" />
+          </div>
+          <h2 className="mt-4 text-base font-semibold text-foreground">
             Something went wrong
           </h2>
-          <p className="text-sm text-gray-600 mb-4">
+          <p className="mt-1.5 text-sm text-muted-foreground">
             {this.state.error?.message || 'An unexpected error occurred'}
           </p>
           <button
             onClick={() => this.setState({ hasError: false, error: undefined })}
-            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            className="mt-4 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
           >
             Try Again
           </button>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,6 +1,5 @@
 import { RefreshCw, Trophy, Calendar } from "lucide-react";
 import { useQueryClient, useIsFetching } from "@tanstack/react-query";
-import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import ThemeToggle from "../settings/ThemeToggle";
 import FavoriteTeamSelector from "../settings/FavoriteTeamSelector";
@@ -22,11 +21,9 @@ export default function Header({
   const isFetching = useIsFetching();
 
   const handleRefresh = () => {
-    // Invalidate scores queries for the current date
     const dateString = format(selectedDate, "yyyyMMdd");
     queryClient.invalidateQueries({ queryKey: ["scores", dateString] });
 
-    // Invalidate window-based queries for the current date
     const normalizedDate = startOfDay(selectedDate);
     const windowStart = addDays(normalizedDate, -2);
     const windowKey = format(windowStart, "yyyyMMdd");
@@ -34,59 +31,80 @@ export default function Header({
       queryKey: ["scores", "window", windowKey],
     });
 
-    // Invalidate standings queries
     queryClient.invalidateQueries({ queryKey: ["standings"] });
   };
 
   return (
-    <header className="bg-gradient-to-r from-nba-primary-600 to-nba-primary-700 dark:from-nba-primary-700 dark:to-nba-primary-800 text-white px-4 py-4 shadow-lg">
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center gap-2">
-          <img src={nbaLogo32} alt="NBA Logo" className="w-6 h-6" />
-          <h1 className="text-xl font-bold bg-gradient-to-r from-white to-blue-100 bg-clip-text text-transparent">
-            NBA Scores
-          </h1>
-        </div>
-        <div className="flex items-center gap-1">
-          <FavoriteTeamSelector />
-          <Button
-            onClick={handleRefresh}
-            disabled={isFetching > 0}
-            variant="ghost"
-            size="icon"
-            className="text-white hover:bg-white/10"
-            title="Refresh all data"
-          >
-            <RefreshCw
-              size={16}
-              className={isFetching > 0 ? "animate-spin" : ""}
-            />
-          </Button>
-          <ThemeToggle />
-        </div>
-      </div>
+    <header className="relative overflow-hidden bg-gradient-to-br from-[#1d4ed8] via-[#1e3a8a] to-[#0f172a] text-white shadow-header">
+      {/* Ambient radial highlight */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-60"
+        style={{
+          background:
+            "radial-gradient(ellipse 70% 120% at 85% -20%, rgba(255,255,255,0.22), transparent 60%)",
+        }}
+      />
+      {/* Subtle top sheen */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-white/30"
+      />
 
-      <Tabs
-        value={currentView}
-        onValueChange={(value) => onViewChange(value as "scores" | "standings")}
-      >
-        <TabsList className="grid w-full grid-cols-2 bg-white/10 backdrop-blur-sm">
-          <TabsTrigger
-            value="scores"
-            className="flex items-center gap-2 text-white data-[state=active]:bg-white/20 data-[state=active]:text-white"
-          >
-            <Calendar size={14} />
-            Scores
-          </TabsTrigger>
-          <TabsTrigger
-            value="standings"
-            className="flex items-center gap-2 text-white data-[state=active]:bg-white/20 data-[state=active]:text-white"
-          >
-            <Trophy size={14} />
-            Standings
-          </TabsTrigger>
-        </TabsList>
-      </Tabs>
+      <div className="relative px-4 pt-3.5 pb-3">
+        <div className="flex items-center justify-between mb-3.5">
+          <div className="flex items-center gap-2">
+            <div className="grid h-8 w-8 place-items-center rounded-lg bg-white/15 ring-1 ring-white/20 backdrop-blur-sm">
+              <img src={nbaLogo32} alt="NBA Logo" className="h-5 w-5" />
+            </div>
+            <div className="flex flex-col leading-none">
+              <h1 className="text-[15px] font-extrabold tracking-tight">
+                NBA Scores
+              </h1>
+              <span className="mt-0.5 text-[10px] font-medium uppercase tracking-[0.16em] text-blue-100/70">
+                Live &amp; Standings
+              </span>
+            </div>
+          </div>
+          <div className="flex items-center gap-1">
+            <FavoriteTeamSelector />
+            <button
+              onClick={handleRefresh}
+              disabled={isFetching > 0}
+              title="Refresh all data"
+              className="grid h-8 w-8 place-items-center rounded-lg text-white/90 transition-colors hover:bg-white/15 disabled:opacity-50"
+            >
+              <RefreshCw
+                size={15}
+                className={isFetching > 0 ? "animate-spin" : ""}
+              />
+            </button>
+            <ThemeToggle />
+          </div>
+        </div>
+
+        <Tabs
+          value={currentView}
+          onValueChange={(value) => onViewChange(value as "scores" | "standings")}
+        >
+          <TabsList className="mx-auto flex h-9 w-auto gap-1 bg-transparent p-0">
+            <TabsTrigger
+              value="scores"
+              className="gap-1.5 rounded-full px-4 text-xs font-semibold data-[state=active]:bg-white/15 data-[state=active]:text-white data-[state=active]:shadow-sm data-[state=inactive]:text-white/55 hover:data-[state=inactive]:text-white/80"
+            >
+              <Calendar size={13} />
+              Scores
+            </TabsTrigger>
+            <TabsTrigger
+              value="standings"
+              className="gap-1.5 rounded-full px-4 text-xs font-semibold data-[state=active]:bg-white/15 data-[state=active]:text-white data-[state=active]:shadow-sm data-[state=inactive]:text-white/55 hover:data-[state=inactive]:text-white/80"
+            >
+              <Trophy size={13} />
+              Standings
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
     </header>
   );
 }

--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -12,7 +12,7 @@ export default function LoadingSpinner({ size = 'md', className = '' }: LoadingS
 
   return (
     <div className={`flex justify-center items-center ${className}`}>
-      <div className={`${sizeClasses[size]} animate-spin rounded-full border-2 border-gray-300 border-t-blue-600`} />
+      <div className={`${sizeClasses[size]} animate-spin rounded-full border-2 border-muted border-t-primary`} />
     </div>
   );
 }

--- a/src/components/scores/DateCarousel.tsx
+++ b/src/components/scores/DateCarousel.tsx
@@ -1,6 +1,5 @@
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { format, addDays, subDays, isToday, isSameDay } from 'date-fns';
-import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
 interface DateCarouselProps {
@@ -28,51 +27,52 @@ export default function DateCarousel({ selectedDate, onDateChange }: DateCarouse
   };
 
   return (
-    <div className="flex items-center bg-muted/50 backdrop-blur-sm rounded-xl p-3 shadow-sm">
-      <Button
+    <div className="flex items-center gap-1 rounded-xl border border-border/60 bg-muted/40 p-1.5 shadow-sm backdrop-blur-sm">
+      <button
         onClick={goToPreviousDay}
-        variant="ghost"
-        size="icon"
-        className="hover:bg-background/60 flex-shrink-0"
+        aria-label="Previous day"
+        className="grid h-8 w-8 flex-shrink-0 place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
       >
         <ChevronLeft size={16} />
-      </Button>
+      </button>
 
-      <div className="flex gap-2 px-2 flex-1 justify-center overflow-hidden">
+      <div className="flex flex-1 justify-center gap-1 overflow-hidden">
         {dates.map((date) => {
           const isSelected = isSameDay(date, selectedDate);
           const isCurrentDay = isToday(date);
 
           return (
-            <Button
+            <button
               key={date.toISOString()}
               onClick={() => onDateChange(date)}
-              variant={isSelected ? "default" : "ghost"}
               className={cn(
-                "flex flex-col h-auto py-1.5 px-1 whitespace-nowrap w-[56px] flex-shrink-0",
-                isSelected && "bg-primary shadow-md",
-                isCurrentDay && !isSelected && "bg-nba-primary-100 dark:bg-nba-primary-900 text-nba-primary-700 dark:text-nba-primary-300"
+                'flex h-[42px] w-[58px] flex-shrink-0 flex-col items-center justify-center rounded-lg transition-all',
+                isSelected
+                  ? 'bg-primary text-primary-foreground shadow-sm'
+                  : 'text-muted-foreground hover:bg-background hover:text-foreground'
               )}
             >
-              <span className="text-xs font-medium leading-tight">
+              <span className={cn('text-[10px] font-medium uppercase leading-none', isSelected ? 'text-primary-foreground/80' : '')}>
                 {format(date, 'EEE')}
               </span>
-              <span className={cn("text-xs leading-tight mt-0.5", isSelected && "font-bold")}>
-                {format(date, 'MMM d')}
+              <span className={cn('mt-0.5 text-xs leading-none tabular-nums', isSelected ? 'font-bold' : 'font-semibold')}>
+                {format(date, 'd')}
               </span>
-            </Button>
+              {isCurrentDay && !isSelected && (
+                <span className="mt-1 h-1 w-1 rounded-full bg-primary" />
+              )}
+            </button>
           );
         })}
       </div>
 
-      <Button
+      <button
         onClick={goToNextDay}
-        variant="ghost"
-        size="icon"
-        className="hover:bg-background/60 flex-shrink-0"
+        aria-label="Next day"
+        className="grid h-8 w-8 flex-shrink-0 place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
       >
         <ChevronRight size={16} />
-      </Button>
+      </button>
     </div>
   );
 }

--- a/src/components/scores/GameCard.tsx
+++ b/src/components/scores/GameCard.tsx
@@ -3,146 +3,151 @@ import { formatGameTime, cn } from '@/lib/utils';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+import { motion } from 'framer-motion';
 
 interface GameCardProps {
   game: Game;
   onCardClick: (gameId: string) => void;
 }
 
+/** Normalize a team color (hex without #, or "ffffff") to an rgba string. */
+function teamColor(color: string | undefined, alpha: number = 1): string {
+  if (!color) return `hsl(var(--foreground) / ${alpha})`;
+  const hex = color.replace('#', '');
+  if (hex.length !== 6) return `hsl(var(--foreground) / ${alpha})`;
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
 export default function GameCard({ game, onCardClick }: GameCardProps) {
-  const getStatusDisplay = () => {
-    switch (game.status) {
-      case 'scheduled':
-        return (
-          <Badge variant="scheduled" className="text-xs">
-            {formatGameTime(game.date)}
+  const isLive = game.status === 'in';
+  const isFinal = game.status === 'final';
+  const isScheduled = game.status === 'scheduled';
+
+  const variant = isLive ? 'live' : isFinal ? 'final' : 'game';
+
+  const hasScore = !!game.score;
+  const awayScore = game.score?.away;
+  const homeScore = game.score?.home;
+  const isAwayWinning = hasScore && awayScore !== undefined && homeScore !== undefined && awayScore > homeScore;
+  const isHomeWinning = hasScore && awayScore !== undefined && homeScore !== undefined && homeScore > awayScore;
+
+  const renderStatus = () => {
+    if (isLive) {
+      return (
+        <div className="flex items-center justify-center gap-1.5">
+          <Badge variant="live" className="gap-1">
+            <span className="relative flex h-1.5 w-1.5">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-live-foreground opacity-75" />
+              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-live-foreground" />
+            </span>
+            LIVE
           </Badge>
-        );
-      case 'in':
-        return (
-          <div className="text-center space-y-1">
-            <Badge variant="live" className="text-xs font-semibold">
-              ● LIVE
-            </Badge>
-            {game.displayClock && game.period && (
-              <div className="text-xs text-muted-foreground">
-                Q{game.period} {game.displayClock}
-              </div>
+          {game.displayClock && game.period && (
+            <span className="tabular-nums text-[11px] font-bold text-live">
+              Q{game.period} · {game.displayClock}
+            </span>
+          )}
+        </div>
+      );
+    }
+    if (isFinal) {
+      const ot = game.period && game.period > 4;
+      return <Badge variant="final">{ot ? 'FINAL/OT' : 'FINAL'}</Badge>;
+    }
+    return (
+      <Badge variant="scheduled">
+        {formatGameTime(game.date)}
+      </Badge>
+    );
+  };
+
+  const renderTeamRow = (team: Game['awayTeam'], isHome: boolean, winning: boolean) => {
+    const score = isHome ? homeScore : awayScore;
+    return (
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <Avatar
+            className={cn(
+              'h-9 w-9 flex-shrink-0 border bg-background/60 ring-1 ring-border/50',
+              isLive && 'border-live/40'
             )}
-          </div>
-        );
-      case 'final':
-        return (
-          <Badge variant="final" className="text-xs">
-            FINAL
-          </Badge>
-        );
-      default:
-        return (
-          <Badge variant="outline" className="text-xs">
-            {String(game.status).toUpperCase()}
-          </Badge>
-        );
-    }
-  };
-
-  const getCardVariant = () => {
-    switch (game.status) {
-      case 'in':
-        return 'game';
-      case 'final':
-        return 'final';
-      default:
-        return 'game';
-    }
-  };
-
-  const getScoreColor = (isWinning: boolean) => {
-    if (!game.score) return 'text-foreground';
-    return isWinning
-      ? 'text-nba-primary-600 dark:text-nba-primary-400 font-bold'
-      : 'text-muted-foreground';
-  };
-
-  const isAwayWinning = game.score && game.score.away > game.score.home;
-  const isHomeWinning = game.score && game.score.home > game.score.away;
-
-  return (
-    <Card
-      variant={getCardVariant()}
-      size="game"
-      onClick={() => onCardClick(game.id)}
-      className="cursor-pointer group"
-    >
-        <div className="space-y-2">
-          {/* Column Headers */}
-          <div className="flex items-center justify-between text-[10px] text-muted-foreground uppercase tracking-wider">
-            <div className="flex-1">Away</div>
-            <div className="px-4 flex-shrink-0"></div>
-            <div className="flex-1 text-right">Home</div>
-          </div>
-
-          {/* Teams Section */}
-          <div className="flex items-center justify-between">
-            {/* Away Team */}
-            <div className="flex items-center space-x-2 min-w-0 flex-1">
-              <Avatar className="h-8 w-8 border border-border flex-shrink-0 group-hover:border-primary/50 transition-colors duration-200">
-                <AvatarImage
-                  src={game.awayTeam.logo}
-                  alt={game.awayTeam.name}
-                  className="object-contain p-1"
-                />
-                <AvatarFallback className="text-xs font-bold bg-muted group-hover:bg-primary/10 group-hover:text-primary transition-colors duration-200">
-                  {game.awayTeam.abbreviation}
-                </AvatarFallback>
-              </Avatar>
-              <div className="text-xs font-semibold truncate min-w-0 group-hover:text-primary transition-colors duration-200">
-                {game.awayTeam.abbreviation}
+          >
+            <AvatarImage src={team.logo} alt={team.name} className="object-contain p-1" />
+            <AvatarFallback className="text-[10px] font-extrabold">{team.abbreviation}</AvatarFallback>
+          </Avatar>
+          <div className="min-w-0">
+            <div className="truncate text-[13px] font-bold leading-tight">
+              {team.abbreviation}
+            </div>
+            {team.record ? (
+              <div className="text-[10px] font-medium text-muted-foreground tabular-nums">
+                {team.record.wins}-{team.record.losses}
               </div>
-            </div>
-
-            {/* VS or Score */}
-            <div className="text-center px-4 flex-shrink-0">
-              {game.score ? (
-                <div className="flex items-center space-x-2">
-                  <div className={cn("text-sm font-bold", getScoreColor(!!isAwayWinning))}>
-                    {game.score.away}
-                  </div>
-                  <div className="text-xs text-muted-foreground">-</div>
-                  <div className={cn("text-sm font-bold", getScoreColor(!!isHomeWinning))}>
-                    {game.score.home}
-                  </div>
-                </div>
-              ) : (
-                <div className="text-xs font-medium text-muted-foreground">
-                  VS
-                </div>
-              )}
-            </div>
-
-            {/* Home Team */}
-            <div className="flex items-center space-x-2 min-w-0 flex-1 justify-end">
-              <div className="text-xs font-semibold truncate min-w-0 text-right group-hover:text-primary transition-colors duration-200">
-                {game.homeTeam.abbreviation}
-              </div>
-              <Avatar className="h-8 w-8 border border-border flex-shrink-0 group-hover:border-primary/50 transition-colors duration-200">
-                <AvatarImage
-                  src={game.homeTeam.logo}
-                  alt={game.homeTeam.name}
-                  className="object-contain p-1"
-                />
-                <AvatarFallback className="text-xs font-bold bg-muted group-hover:bg-primary/10 group-hover:text-primary transition-colors duration-200">
-                  {game.homeTeam.abbreviation}
-                </AvatarFallback>
-              </Avatar>
-            </div>
-          </div>
-
-          {/* Status */}
-          <div className="text-center">
-            {getStatusDisplay()}
+            ) : null}
           </div>
         </div>
+        {hasScore && score !== undefined ? (
+          <span
+            className={cn(
+              'tabular-nums text-2xl font-extrabold leading-none',
+              winning ? 'text-foreground' : 'text-muted-foreground/70'
+            )}
+          >
+            {score}
+          </span>
+        ) : isScheduled ? (
+          <span className="text-xs font-medium text-muted-foreground/60">vs</span>
+        ) : null}
+      </div>
+    );
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+      whileHover={{ y: -2 }}
+      whileTap={{ scale: 0.98 }}
+    >
+      <Card
+        variant={variant}
+        size="game"
+        onClick={() => onCardClick(game.id)}
+        className="group relative cursor-pointer overflow-hidden"
+      >
+        {/* Team-color accent strip */}
+        {!isLive && (
+          <div
+            aria-hidden
+            className="absolute inset-x-0 top-0 h-1"
+            style={{
+              background: `linear-gradient(90deg, ${teamColor(game.awayTeam?.color, 0.95)} 0%, ${teamColor(game.awayTeam?.color, 0.5)} 50%, ${teamColor(game.homeTeam?.color, 0.95)} 100%)`,
+            }}
+          />
+        )}
+
+        {/* Status header */}
+        <div className="flex items-center justify-center pt-2.5 pb-1.5">
+          {renderStatus()}
+        </div>
+
+        {/* Teams */}
+        <div className="space-y-1.5 px-3 pb-3 pt-1">
+          {renderTeamRow(game.awayTeam, false, !!isAwayWinning)}
+          <div className="flex items-center gap-3 py-0.5">
+            <div className="h-px flex-1 bg-border/60" />
+            <span className="text-[9px] font-bold uppercase tracking-widest text-muted-foreground/50">
+              {isLive ? 'In Progress' : isFinal ? 'Final' : 'Matchup'}
+            </span>
+            <div className="h-px flex-1 bg-border/60" />
+          </div>
+          {renderTeamRow(game.homeTeam, true, !!isHomeWinning)}
+        </div>
       </Card>
+    </motion.div>
   );
 }

--- a/src/components/scores/GamePreview.tsx
+++ b/src/components/scores/GamePreview.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { ArrowLeft, X } from 'lucide-react';
+import { ArrowLeft, X, FileX2 } from 'lucide-react';
 import { BoxScore, Team, BoxScoreStatistic } from '@/types/game';
-import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { motion } from 'framer-motion';
 
 interface GamePreviewProps {
   boxScore: BoxScore | null;
@@ -11,29 +11,46 @@ interface GamePreviewProps {
   onClose: () => void;
 }
 
+function teamColor(color: string | undefined, alpha: number = 1): string {
+  if (!color) return `hsl(var(--foreground) / ${alpha})`;
+  const hex = color.replace('#', '');
+  if (hex.length !== 6) return `hsl(var(--foreground) / ${alpha})`;
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
 const GamePreview: React.FC<GamePreviewProps> = ({ boxScore, isLoading, onClose }) => {
   if (isLoading) {
     return (
       <div className="w-full h-96 flex items-center justify-center">
-        <Card className="w-full h-full flex items-center justify-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-        </Card>
+        <div className="flex flex-col items-center gap-3">
+          <div className="h-8 w-8 animate-spin rounded-full border-2 border-muted border-t-primary" />
+          <span className="text-sm text-muted-foreground">Loading box score...</span>
+        </div>
       </div>
     );
   }
 
   if (!boxScore || !boxScore.boxscore) {
     return (
-      <div className="w-full h-96 flex items-center justify-center">
-        <Card className="w-full h-full p-6 flex flex-col">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-bold">Game Details</h2>
-            <Button variant="ghost" size="sm" onClick={onClose}>
-              <X className="h-4 w-4" />
-            </Button>
+      <div className="w-full space-y-3">
+        <div className="flex items-center justify-between rounded-xl border border-border bg-card p-3 shadow-card">
+          <h2 className="text-sm font-bold">Game Details</h2>
+          <button
+            onClick={onClose}
+            className="grid h-8 w-8 place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <div className="grid h-12 w-12 place-items-center rounded-full bg-muted text-muted-foreground">
+            <FileX2 className="h-6 w-6" />
           </div>
-          <p className="text-center text-gray-500">Unable to load game details</p>
-        </Card>
+          <p className="mt-3 text-sm text-muted-foreground">Unable to load game details</p>
+        </div>
       </div>
     );
   }
@@ -41,7 +58,6 @@ const GamePreview: React.FC<GamePreviewProps> = ({ boxScore, isLoading, onClose 
   const { teams, players } = boxScore.boxscore;
   const leaders = boxScore.leaders || [];
 
-  // Map technical statistic names to user-friendly abbreviations
   const getStatDisplayName = (stat: BoxScoreStatistic): string => {
     const nameMap: Record<string, string> = {
       'fieldGoalsMade-fieldGoalsAttempted': 'FG',
@@ -68,17 +84,14 @@ const GamePreview: React.FC<GamePreviewProps> = ({ boxScore, isLoading, onClose 
       'efficiency': 'EFF',
       'minutes': 'MIN'
     };
-
     return stat.abbreviation || nameMap[stat.name] || stat.name;
   };
 
   const getTeamScore = (teamId: string) => {
     const playerStats = players.find(p => p.team.id === teamId);
     if (!playerStats || !playerStats.statistics[0]) return 0;
-    
     const pointsIndex = playerStats.statistics[0].names.findIndex(name => name === 'PTS');
     if (pointsIndex === -1) return 0;
-    
     return playerStats.statistics[0].athletes
       .filter(athlete => !athlete.didNotPlay)
       .reduce((total, athlete) => {
@@ -91,124 +104,132 @@ const GamePreview: React.FC<GamePreviewProps> = ({ boxScore, isLoading, onClose 
     const teamStats = teams.find(t => t.team.id === team.id);
     const playerStats = players.find(p => p.team.id === team.id);
     const score = getTeamScore(team.id);
-    
+
     if (!teamStats || !playerStats) {
       return (
         <Card className="p-4">
-          <p className="text-gray-500 text-center">Team data not available</p>
+          <p className="text-muted-foreground text-center text-sm">Team data not available</p>
         </Card>
       );
     }
 
-    // Show all available team statistics
     const mainStats = teamStats.statistics.slice(0, 12);
     const playerData = playerStats.statistics[0];
+    const accent = teamColor(team.color, 1);
 
     return (
-      <Card className="p-4 space-y-4">
-        {/* Team Header */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <img 
-              src={team.logo} 
-              alt={team.displayName}
-              className="w-10 h-10"
-              onError={(e) => {
-                e.currentTarget.src = '';
-                e.currentTarget.style.display = 'none';
-              }}
-            />
-            <div>
-              <h3 className="font-semibold text-sm">{team.displayName}</h3>
-              <p className="text-2xl font-bold">{score}</p>
+      <Card variant="elevated" className="overflow-hidden">
+        <div className="h-1" style={{ background: accent }} />
+        <div className="space-y-3 p-3">
+          {/* Team header */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2.5">
+              <div
+                className="grid h-10 w-10 place-items-center rounded-lg border border-border/60 bg-background/60"
+                style={{ boxShadow: `inset 0 0 0 2px ${teamColor(team.color, 0.25)}` }}
+              >
+                <img
+                  src={team.logo}
+                  alt={team.displayName}
+                  className="h-8 w-8 object-contain"
+                  onError={(e) => { e.currentTarget.style.display = 'none'; }}
+                />
+              </div>
+              <div>
+                <h3 className="text-sm font-bold leading-tight">{team.displayName}</h3>
+                <Badge variant="record" className="mt-0.5">{isHome ? 'HOME' : 'AWAY'}</Badge>
+              </div>
             </div>
+            <span className="tabular-nums text-3xl font-extrabold leading-none">{score}</span>
           </div>
-          <Badge variant="secondary" className="text-xs">
-            {isHome ? 'HOME' : 'AWAY'}
-          </Badge>
+
+          {/* Team statistics */}
+          {mainStats.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                Team Statistics
+              </h4>
+              <div className="grid grid-cols-3 gap-1.5">
+                {mainStats.map((stat, index) => (
+                  <div key={index} className="rounded-md bg-muted/40 px-2 py-1.5">
+                    <div className="text-[9px] font-medium uppercase text-muted-foreground">{getStatDisplayName(stat)}</div>
+                    <div className="text-xs font-bold tabular-nums">{stat.displayValue || '-'}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Player statistics */}
+          {playerData && playerData.athletes.length > 0 && (
+            <div className="space-y-1.5">
+              <h4 className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                Player Statistics
+              </h4>
+              <div className="overflow-x-auto scrollbar-thin -mx-1 px-1">
+                <table className="w-full border-collapse text-[11px]">
+                  <thead>
+                    <tr className="border-b border-border text-left text-muted-foreground">
+                      <th className="sticky left-0 bg-elevated pb-1.5 pr-2 font-semibold">Player</th>
+                      <th className="px-1 pb-1.5 text-center font-semibold">MIN</th>
+                      <th className="px-1 pb-1.5 text-center font-semibold">FG</th>
+                      <th className="px-1 pb-1.5 text-center font-semibold">3PT</th>
+                      <th className="px-1 pb-1.5 text-center font-semibold">FT</th>
+                      <th className="px-1 pb-1.5 text-center font-semibold">REB</th>
+                      <th className="px-1 pb-1.5 text-center font-semibold">AST</th>
+                      <th className="px-1 pb-1.5 text-center font-semibold">STL</th>
+                      <th className="px-1 pb-1.5 text-center font-semibold">BLK</th>
+                      <th className="px-1 pb-1.5 text-center font-semibold">TO</th>
+                      <th className="px-1 pb-1.5 text-center font-semibold">PF</th>
+                      <th className="px-1 pb-1.5 text-center font-semibold">+/-</th>
+                      <th className="px-1 pb-1.5 text-center font-semibold">PTS</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {playerData.athletes
+                      .filter(athlete => !athlete.didNotPlay)
+                      .map((athlete) => {
+                        const minutesIndex = playerData.names.findIndex(name => name === 'MIN');
+                        const fgIndex = playerData.names.findIndex(name => name === 'FG');
+                        const threePtIndex = playerData.names.findIndex(name => name === '3PT');
+                        const ftIndex = playerData.names.findIndex(name => name === 'FT');
+                        const rebIndex = playerData.names.findIndex(name => name === 'REB');
+                        const astIndex = playerData.names.findIndex(name => name === 'AST');
+                        const stlIndex = playerData.names.findIndex(name => name === 'STL');
+                        const blkIndex = playerData.names.findIndex(name => name === 'BLK');
+                        const toIndex = playerData.names.findIndex(name => name === 'TO');
+                        const pfIndex = playerData.names.findIndex(name => name === 'PF');
+                        const plusMinusIndex = playerData.names.findIndex(name => name === '+/-');
+                        const ptsIndex = playerData.names.findIndex(name => name === 'PTS');
+                        const plusMinus = athlete.stats[plusMinusIndex] || '';
+
+                        return (
+                          <tr key={athlete.athlete.id} className="border-b border-border/40 hover:bg-accent/30">
+                            <td className="sticky left-0 bg-elevated py-1.5 pr-2">
+                              <div className="font-semibold text-foreground">{athlete.athlete.displayName}</div>
+                              <div className="text-[10px] text-muted-foreground">#{athlete.athlete.jersey} {athlete.athlete.position.abbreviation}</div>
+                            </td>
+                            <td className="px-1 py-1.5 text-center tabular-nums">{athlete.stats[minutesIndex] || '-'}</td>
+                            <td className="px-1 py-1.5 text-center tabular-nums">{athlete.stats[fgIndex] || '-'}</td>
+                            <td className="px-1 py-1.5 text-center tabular-nums">{athlete.stats[threePtIndex] || '-'}</td>
+                            <td className="px-1 py-1.5 text-center tabular-nums">{athlete.stats[ftIndex] || '-'}</td>
+                            <td className="px-1 py-1.5 text-center tabular-nums">{athlete.stats[rebIndex] || '-'}</td>
+                            <td className="px-1 py-1.5 text-center tabular-nums">{athlete.stats[astIndex] || '-'}</td>
+                            <td className="px-1 py-1.5 text-center tabular-nums">{athlete.stats[stlIndex] || '-'}</td>
+                            <td className="px-1 py-1.5 text-center tabular-nums">{athlete.stats[blkIndex] || '-'}</td>
+                            <td className="px-1 py-1.5 text-center tabular-nums">{athlete.stats[toIndex] || '-'}</td>
+                            <td className="px-1 py-1.5 text-center tabular-nums">{athlete.stats[pfIndex] || '-'}</td>
+                            <td className="px-1 py-1.5 text-center tabular-nums">{plusMinus}</td>
+                            <td className="px-1 py-1.5 text-center font-bold tabular-nums">{athlete.stats[ptsIndex] || '-'}</td>
+                          </tr>
+                        );
+                      })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
         </div>
-        
-        {/* Team Statistics */}
-        {mainStats.length > 0 && (
-          <div className="space-y-2">
-            <h4 className="font-medium text-xs text-gray-600 uppercase tracking-wide">Team Statistics</h4>
-            <div className="grid grid-cols-3 gap-3 text-xs">
-              {mainStats.map((stat, index) => (
-                <div key={index} className="flex justify-between">
-                  <span className="text-gray-600">{getStatDisplayName(stat)}:</span>
-                  <span className="font-medium">{stat.displayValue || '-'}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Player Statistics */}
-        {playerData && playerData.athletes.length > 0 && (
-          <div className="space-y-2">
-            <h4 className="font-medium text-xs text-gray-600 uppercase tracking-wide">Player Statistics</h4>
-            <div className="overflow-x-auto">
-              <table className="w-full text-xs">
-                <thead>
-                  <tr className="text-left text-gray-500 border-b">
-                    <th className="pb-2 font-medium">Player</th>
-                    <th className="pb-2 text-center font-medium">MIN</th>
-                    <th className="pb-2 text-center font-medium">FG</th>
-                    <th className="pb-2 text-center font-medium">3PT</th>
-                    <th className="pb-2 text-center font-medium">FT</th>
-                    <th className="pb-2 text-center font-medium">REB</th>
-                    <th className="pb-2 text-center font-medium">AST</th>
-                    <th className="pb-2 text-center font-medium">STL</th>
-                    <th className="pb-2 text-center font-medium">BLK</th>
-                    <th className="pb-2 text-center font-medium">TO</th>
-                    <th className="pb-2 text-center font-medium">PF</th>
-                    <th className="pb-2 text-center font-medium">+/-</th>
-                    <th className="pb-2 text-center font-medium">PTS</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {playerData.athletes
-                    .filter(athlete => !athlete.didNotPlay)
-                    .map((athlete) => {
-                      const minutesIndex = playerData.names.findIndex(name => name === 'MIN');
-                      const fgIndex = playerData.names.findIndex(name => name === 'FG');
-                      const threePtIndex = playerData.names.findIndex(name => name === '3PT');
-                      const ftIndex = playerData.names.findIndex(name => name === 'FT');
-                      const rebIndex = playerData.names.findIndex(name => name === 'REB');
-                      const astIndex = playerData.names.findIndex(name => name === 'AST');
-                      const stlIndex = playerData.names.findIndex(name => name === 'STL');
-                      const blkIndex = playerData.names.findIndex(name => name === 'BLK');
-                      const toIndex = playerData.names.findIndex(name => name === 'TO');
-                      const pfIndex = playerData.names.findIndex(name => name === 'PF');
-                      const plusMinusIndex = playerData.names.findIndex(name => name === '+/-');
-                      const ptsIndex = playerData.names.findIndex(name => name === 'PTS');
-
-                      return (
-                        <tr key={athlete.athlete.id} className="border-b border-gray-100">
-                          <td className="py-2">
-                            <div className="font-medium">{athlete.athlete.displayName}</div>
-                            <div className="text-gray-500">#{athlete.athlete.jersey} {athlete.athlete.position.abbreviation}</div>
-                          </td>
-                          <td className="py-2 text-center">{athlete.stats[minutesIndex] || '-'}</td>
-                          <td className="py-2 text-center">{athlete.stats[fgIndex] || '-'}</td>
-                          <td className="py-2 text-center">{athlete.stats[threePtIndex] || '-'}</td>
-                          <td className="py-2 text-center">{athlete.stats[ftIndex] || '-'}</td>
-                          <td className="py-2 text-center">{athlete.stats[rebIndex] || '-'}</td>
-                          <td className="py-2 text-center">{athlete.stats[astIndex] || '-'}</td>
-                          <td className="py-2 text-center">{athlete.stats[stlIndex] || '-'}</td>
-                          <td className="py-2 text-center">{athlete.stats[blkIndex] || '-'}</td>
-                          <td className="py-2 text-center">{athlete.stats[toIndex] || '-'}</td>
-                          <td className="py-2 text-center">{athlete.stats[pfIndex] || '-'}</td>
-                          <td className="py-2 text-center">{athlete.stats[plusMinusIndex] || '-'}</td>
-                          <td className="py-2 text-center font-medium">{athlete.stats[ptsIndex] || '-'}</td>
-                        </tr>
-                      );
-                    })}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        )}
       </Card>
     );
   };
@@ -217,49 +238,45 @@ const GamePreview: React.FC<GamePreviewProps> = ({ boxScore, isLoading, onClose 
     if (!leaders.length) return null;
 
     return (
-      <Card className="p-4 space-y-4">
-        <h4 className="font-medium text-xs text-gray-600 uppercase tracking-wide">Game Leaders</h4>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <Card variant="elevated" className="space-y-3 p-3">
+        <h4 className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+          Game Leaders
+        </h4>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           {leaders.map((teamLeader) => (
-            <div key={teamLeader.team.id} className="space-y-3">
-              <div className="flex items-center gap-2">
-                 <img 
-                   src={teamLeader.team.logo} 
-                   alt={teamLeader.team.displayName}
-                   className="w-5 h-5"
-                   onError={(e) => {
-                     e.currentTarget.src = '';
-                     e.currentTarget.style.display = 'none';
-                   }}
-                 />
-                <span className="font-medium text-sm">{teamLeader.team.displayName}</span>
+            <div key={teamLeader.team.id} className="space-y-2">
+              <div className="flex items-center gap-1.5">
+                <img
+                  src={teamLeader.team.logo}
+                  alt={teamLeader.team.displayName}
+                  className="h-4 w-4"
+                  onError={(e) => { e.currentTarget.style.display = 'none'; }}
+                />
+                <span className="text-xs font-semibold">{teamLeader.team.displayName}</span>
               </div>
-              <div className="space-y-2">
+              <div className="space-y-1.5">
                 {teamLeader.leaders.map((category) => (
-                  <div key={category.name} className="flex items-center justify-between p-3 border border-border rounded-lg">
-                    <div className="flex items-center gap-3">
-                      <span className="text-xs font-medium text-muted-foreground min-w-[60px]">
+                  <div key={category.name} className="flex items-center justify-between rounded-lg border border-border/60 bg-muted/30 p-2">
+                    <div className="flex items-center gap-2">
+                      <span className="text-[10px] font-bold uppercase tracking-wide text-muted-foreground min-w-[42px]">
                         {category.displayName}
                       </span>
                       {category.leaders.map((leader, idx) => (
-                        <div key={idx} className="flex items-center gap-2">
-                          <img 
-                            src={leader.athlete.headshot?.href || ''} 
+                        <div key={idx} className="flex items-center gap-1.5">
+                          <img
+                            src={leader.athlete.headshot?.href || ''}
                             alt={leader.athlete.displayName}
-                            className="w-6 h-6 rounded-full"
-                            onError={(e) => {
-                              e.currentTarget.src = '';
-                              e.currentTarget.style.display = 'none';
-                            }}
+                            className="h-6 w-6 rounded-full object-cover"
+                            onError={(e) => { e.currentTarget.style.display = 'none'; }}
                           />
                           <div>
-                            <span className="text-xs font-medium">{leader.athlete.displayName}</span>
-                            <span className="text-xs text-muted-foreground ml-1">#{leader.athlete.jersey}</span>
+                            <span className="text-[11px] font-medium">{leader.athlete.displayName}</span>
+                            <span className="text-[10px] text-muted-foreground ml-0.5">#{leader.athlete.jersey}</span>
                           </div>
                         </div>
                       ))}
                     </div>
-                    <span className="text-sm font-semibold">{category.leaders[0]?.displayValue}</span>
+                    <span className="text-sm font-bold tabular-nums">{category.leaders[0]?.displayValue}</span>
                   </div>
                 ))}
               </div>
@@ -272,29 +289,44 @@ const GamePreview: React.FC<GamePreviewProps> = ({ boxScore, isLoading, onClose 
 
   const awayTeam = teams.find(t => t.homeAway === 'away')?.team;
   const homeTeam = teams.find(t => t.homeAway === 'home')?.team;
+  const headline = awayTeam && homeTeam ? `${awayTeam.abbreviation} @ ${homeTeam.abbreviation}` : 'Box Score';
 
   return (
-    <div className="w-full space-y-4">
-      <Card className="p-4">
+    <motion.div
+      initial={{ opacity: 0, x: 12 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.28, ease: [0.22, 1, 0.36, 1] }}
+      className="w-full space-y-3"
+    >
+      <Card variant="elevated" className="p-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <Button variant="ghost" size="sm" onClick={onClose}>
+            <button
+              onClick={onClose}
+              className="grid h-8 w-8 place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
               <ArrowLeft className="h-4 w-4" />
-            </Button>
-            <h2 className="text-lg font-bold">Box Score</h2>
+            </button>
+            <div>
+              <h2 className="text-sm font-bold leading-tight">{headline}</h2>
+              <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Box Score</span>
+            </div>
           </div>
-          <Button variant="ghost" size="sm" onClick={onClose}>
+          <button
+            onClick={onClose}
+            className="grid h-8 w-8 place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
             <X className="h-4 w-4" />
-          </Button>
+          </button>
         </div>
       </Card>
 
-      <div className="space-y-4">
+      <div className="space-y-3">
         {awayTeam && renderTeamCard(awayTeam, false)}
         {homeTeam && renderTeamCard(homeTeam, true)}
         {renderLeaders()}
       </div>
-    </div>
+    </motion.div>
   );
 };
 

--- a/src/components/scores/ScoresList.tsx
+++ b/src/components/scores/ScoresList.tsx
@@ -9,7 +9,7 @@ import GamePreview from "./GamePreview";
 import DateCarousel from "./DateCarousel";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { RefreshCw, AlertCircle } from "lucide-react";
+import { RefreshCw, AlertCircle, CalendarOff } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { sportsApi } from "../../services/api";
 import { format, startOfDay, addDays } from "date-fns";
@@ -17,21 +17,33 @@ import nbaLogo48 from "/icons/icon48.png";
 
 function GameCardSkeleton() {
   return (
-    <div className="p-3 rounded-lg border bg-card">
-      <div className="space-y-3">
+    <div className="overflow-hidden rounded-xl border border-border bg-card shadow-card">
+      <div className="flex items-center justify-center pt-2.5 pb-1.5">
+        <Skeleton className="h-4 w-14 rounded-full" />
+      </div>
+      <div className="space-y-1.5 px-3 pb-3 pt-1">
         <div className="flex items-center justify-between">
-          <div className="flex items-center space-x-2">
-            <Skeleton className="h-8 w-8 rounded-full" />
-            <Skeleton className="h-3 w-8" />
+          <div className="flex items-center gap-2.5">
+            <Skeleton className="h-9 w-9 rounded-full" />
+            <div className="space-y-1">
+              <Skeleton className="h-3 w-10" />
+              <Skeleton className="h-2 w-8" />
+            </div>
           </div>
-          <Skeleton className="h-4 w-10" />
-          <div className="flex items-center space-x-2">
-            <Skeleton className="h-3 w-8" />
-            <Skeleton className="h-8 w-8 rounded-full" />
-          </div>
+          <Skeleton className="h-6 w-7" />
         </div>
-        <div className="text-center">
-          <Skeleton className="h-6 w-16 mx-auto" />
+        <div className="flex items-center gap-3 py-0.5">
+          <div className="h-px flex-1 bg-border/40" />
+        </div>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2.5">
+            <Skeleton className="h-9 w-9 rounded-full" />
+            <div className="space-y-1">
+              <Skeleton className="h-3 w-10" />
+              <Skeleton className="h-2 w-8" />
+            </div>
+          </div>
+          <Skeleton className="h-6 w-7" />
         </div>
       </div>
     </div>
@@ -63,7 +75,6 @@ export default function ScoresList({
     return sortGamesByPriority(games, favoriteTeam);
   }, [games, favoriteTeam]);
 
-  // Prefetch adjacent windows for smoother navigation
   useEffect(() => {
     const prefetchWindow = (date: Date) => {
       const normalizedDate = startOfDay(date);
@@ -77,17 +88,15 @@ export default function ScoresList({
           const dateRange = `${startDate}-${endDate}`;
           return await sportsApi.getScoreboard(dateRange);
         },
-        staleTime: 5 * 60 * 1000, // 5 minutes
+        staleTime: 5 * 60 * 1000,
       });
     };
 
-    // Prefetch previous and next windows
-    prefetchWindow(addDays(selectedDate, -5)); // Previous window
-    prefetchWindow(addDays(selectedDate, 5)); // Next window
+    prefetchWindow(addDays(selectedDate, -5));
+    prefetchWindow(addDays(selectedDate, 5));
   }, [selectedDate, queryClient]);
 
   const handleRefresh = () => {
-    // Calculate the window key for the current selected date
     const normalizedDate = startOfDay(selectedDate);
     const windowStart = addDays(normalizedDate, -2);
     const windowKey = format(windowStart, "yyyyMMdd");
@@ -102,7 +111,6 @@ export default function ScoresList({
       openPreview(gameId);
     } catch (error) {
       console.error("Failed to open game preview:", error);
-      // Reset selected game ID on error
       setSelectedGameId(null);
     }
   };
@@ -114,9 +122,9 @@ export default function ScoresList({
 
   if (isLoading || (isFetching && !games)) {
     return (
-      <div className="space-y-4">
+      <div className="space-y-3">
         <DateCarousel selectedDate={selectedDate} onDateChange={onDateChange} />
-        <div className="grid grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 gap-3">
           {Array.from({ length: 6 }).map((_, i) => (
             <GameCardSkeleton key={i} />
           ))}
@@ -127,17 +135,17 @@ export default function ScoresList({
 
   if (error) {
     return (
-      <div className="space-y-4">
+      <div className="space-y-3">
         <DateCarousel selectedDate={selectedDate} onDateChange={onDateChange} />
-        <div className="py-8 text-center space-y-4">
-          <div className="flex items-center justify-center text-destructive mb-2">
-            <AlertCircle className="h-6 w-6 mr-2" />
-            <span className="font-semibold">Failed to load games</span>
+        <div className="py-10 text-center space-y-3">
+          <div className="mx-auto grid h-12 w-12 place-items-center rounded-full bg-destructive/10 text-destructive">
+            <AlertCircle className="h-6 w-6" />
           </div>
+          <span className="block font-semibold">Failed to load games</span>
           <p className="text-muted-foreground text-sm">
             Check your internet connection or try again later
           </p>
-          <Button onClick={handleRefresh} variant="outline" className="mt-4">
+          <Button onClick={handleRefresh} variant="outline" size="sm" className="mt-2">
             <RefreshCw className="h-4 w-4 mr-2" />
             Try Again
           </Button>
@@ -147,13 +155,12 @@ export default function ScoresList({
   }
 
   return (
-    <div className="space-y-2 w-full">
+    <div className="space-y-3 w-full">
       <DateCarousel selectedDate={selectedDate} onDateChange={onDateChange} />
 
-      {/* Background refresh indicator */}
       {isFetching && games && (
-        <div className="flex items-center justify-center text-xs text-muted-foreground py-1">
-          <RefreshCw className="h-3 w-3 mr-1 animate-spin" />
+        <div className="flex items-center justify-center gap-1.5 text-[11px] font-medium text-muted-foreground py-1">
+          <RefreshCw className="h-3 w-3 animate-spin" />
           Updating scores...
         </div>
       )}
@@ -166,34 +173,35 @@ export default function ScoresList({
             onClose={handleBackToScores}
           />
         ) : sortedGames && sortedGames.length > 0 ? (
-          <div className="w-full">
-            <div className="grid grid-cols-3 gap-2 w-full">
-              {sortedGames.map((game) => (
-                <GameCard
-                  key={game.id}
-                  game={game}
-                  onCardClick={() => {
-                    if (game.status === "in" || game.status === "final") {
-                      handleGameClick(game.id);
-                    }
-                  }}
-                />
-              ))}
-            </div>
+          <div className="grid grid-cols-2 gap-3 w-full">
+            {sortedGames.map((game) => (
+              <GameCard
+                key={game.id}
+                game={game}
+                onCardClick={() => {
+                  if (game.status === "in" || game.status === "final") {
+                    handleGameClick(game.id);
+                  }
+                }}
+              />
+            ))}
           </div>
         ) : (
-          <div className="text-center py-12">
+          <div className="flex flex-col items-center justify-center py-14 text-center">
+            <div className="grid h-16 w-16 place-items-center rounded-2xl bg-muted/60 ring-1 ring-border/60">
+              <CalendarOff className="h-7 w-7 text-muted-foreground" />
+            </div>
+            <h3 className="mt-4 text-base font-semibold text-foreground">
+              No games scheduled
+            </h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Try selecting a different date to see more games
+            </p>
             <img
               src={nbaLogo48}
               alt="NBA Logo"
-              className="w-24 h-24 mb-4 mx-auto"
+              className="mt-5 h-8 w-8 opacity-30"
             />
-            <h3 className="text-lg font-semibold text-foreground mb-2">
-              No games scheduled
-            </h3>
-            <p className="text-muted-foreground">
-              Try selecting a different date to see more games
-            </p>
           </div>
         )}
       </div>

--- a/src/components/settings/FavoriteTeamSelector.tsx
+++ b/src/components/settings/FavoriteTeamSelector.tsx
@@ -1,4 +1,4 @@
-import { Star } from "lucide-react";
+import { Star, ChevronDown } from "lucide-react";
 import { useFavoriteTeam } from "@/hooks/useFavoriteTeam";
 import {
   Select,
@@ -35,22 +35,23 @@ export default function FavoriteTeamSelector() {
   return (
     <Select value={favoriteTeam || "none"} onValueChange={handleValueChange}>
       <SelectTrigger
-        className="h-8 w-auto min-w-[70px] border-0 bg-transparent text-white hover:bg-white/10 focus:ring-0 focus:ring-offset-0 gap-1"
+        className="h-8 w-auto min-w-[72px] gap-1 border-0 bg-transparent px-2 text-white/90 hover:bg-white/15 focus:ring-0 focus:ring-offset-0 data-[state=open]:bg-white/15"
         title="Select favorite team"
       >
         <Star
           size={14}
-          className={favoriteTeam ? "fill-yellow-400 text-yellow-400" : ""}
+          className={favoriteTeam ? "fill-yellow-400 text-yellow-400" : "text-white/80"}
         />
         <SelectValue>
           {selectedTeam ? selectedTeam.abbreviation : "FAV"}
         </SelectValue>
+        <ChevronDown size={12} className="opacity-60" />
       </SelectTrigger>
       <SelectContent className="max-h-[300px]">
         <SelectItem value="none">No favorite</SelectItem>
         {teams.map((team) => (
           <SelectItem key={team.id} value={team.id}>
-            {team.abbreviation} - {team.name}
+            {team.abbreviation} · {team.name}
           </SelectItem>
         ))}
       </SelectContent>

--- a/src/components/settings/ThemeToggle.tsx
+++ b/src/components/settings/ThemeToggle.tsx
@@ -1,5 +1,4 @@
 import { Sun, Moon, Monitor } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 import { useTheme } from '../../hooks/useTheme';
 import { motion } from 'framer-motion';
 
@@ -9,13 +8,13 @@ export default function ThemeToggle() {
   const getIcon = () => {
     switch (theme) {
       case 'light':
-        return <Sun size={16} />;
+        return <Sun size={15} />;
       case 'dark':
-        return <Moon size={16} />;
+        return <Moon size={15} />;
       case 'system':
-        return <Monitor size={16} />;
+        return <Monitor size={15} />;
       default:
-        return <Sun size={16} />;
+        return <Sun size={15} />;
     }
   };
 
@@ -33,12 +32,10 @@ export default function ThemeToggle() {
   };
 
   return (
-    <Button
+    <button
       onClick={toggleTheme}
-      variant="ghost"
-      size="icon"
-      className="text-white hover:bg-white/10 transition-all duration-200 hover:scale-105"
       title={getLabel()}
+      className="grid h-8 w-8 place-items-center rounded-lg text-white/90 transition-all duration-200 hover:scale-105 hover:bg-white/15"
     >
       <motion.div
         key={theme}
@@ -48,6 +45,6 @@ export default function ThemeToggle() {
       >
         {getIcon()}
       </motion.div>
-    </Button>
+    </button>
   );
 }

--- a/src/components/standings/ConferenceStandings.tsx
+++ b/src/components/standings/ConferenceStandings.tsx
@@ -15,7 +15,7 @@ export default function ConferenceStandings({ conference }: ConferenceStandingsP
           <img
             src={nbaLogo48}
             alt="NBA Logo"
-            className="w-16 h-16 mb-4 mx-auto"
+            className="w-16 h-16 mb-4 mx-auto opacity-40"
           />
           <h3 className="text-lg font-semibold text-foreground mb-2">
             No standings available
@@ -29,25 +29,25 @@ export default function ConferenceStandings({ conference }: ConferenceStandingsP
   }
 
   return (
-    <Card className="overflow-hidden w-full">
-      {/* Table Header */}
-      <div className="bg-muted/30 px-2 py-2 border-b border-border">
-        <div className="flex items-center justify-between text-xs font-medium text-muted-foreground uppercase tracking-wide">
-          <div className="flex items-center space-x-3 flex-1">
-            <span className="w-6 text-center">#</span>
-            <span>Team</span>
-          </div>
-          <div className="flex space-x-4 text-center">
-            <span className="w-8">W</span>
-            <span className="w-8">L</span>
-            <span className="w-12">PCT</span>
-            <span className="w-8">GB</span>
-          </div>
+    <div className="overflow-hidden rounded-xl border border-border bg-card shadow-card">
+      {/* Table header */}
+      <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/40 px-2.5 py-2">
+        <div className="flex items-center gap-2.5">
+          <span className="grid h-6 w-6 place-items-center text-[10px] font-bold text-muted-foreground">#</span>
+          <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            Team
+          </span>
+        </div>
+        <div className="flex items-center text-center text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+          <span className="w-8">W</span>
+          <span className="w-8">L</span>
+          <span className="w-12">PCT</span>
+          <span className="w-8">GB</span>
         </div>
       </div>
 
-      {/* Team Standings */}
-      <div className="divide-y divide-border">
+      {/* Team standings */}
+      <div className="divide-y divide-border/50">
         {conference.standings.map((teamStanding, index) => (
           <TeamStandingRow
             key={teamStanding.team.id}
@@ -56,6 +56,6 @@ export default function ConferenceStandings({ conference }: ConferenceStandingsP
           />
         ))}
       </div>
-    </Card>
+    </div>
   );
 }

--- a/src/components/standings/StandingsList.tsx
+++ b/src/components/standings/StandingsList.tsx
@@ -4,22 +4,22 @@ import ConferenceStandings from './ConferenceStandings';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Skeleton } from '@/components/ui/skeleton';
-import { RefreshCw, AlertCircle } from 'lucide-react';
+import { RefreshCw, AlertCircle, Trophy } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 
 function StandingsSkeletonRow() {
   return (
-    <div className="flex items-center justify-between px-2 py-2 border-b border-border">
-      <div className="flex items-center space-x-2 flex-1">
-        <Skeleton className="h-6 w-6" />
+    <div className="flex items-center justify-between gap-2 border-l-2 border-l-transparent px-2.5 py-2">
+      <div className="flex items-center gap-2.5 flex-1">
+        <Skeleton className="h-6 w-6 rounded-md" />
         <Skeleton className="h-7 w-7 rounded-full" />
-        <Skeleton className="h-4 w-20" />
+        <Skeleton className="h-4 w-24" />
       </div>
-      <div className="flex space-x-6">
-        <Skeleton className="h-4 w-8" />
-        <Skeleton className="h-4 w-8" />
-        <Skeleton className="h-4 w-12" />
-        <Skeleton className="h-4 w-8" />
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-4 w-6" />
+        <Skeleton className="h-4 w-6" />
+        <Skeleton className="h-4 w-10" />
+        <Skeleton className="h-4 w-6" />
       </div>
     </div>
   );
@@ -27,26 +27,39 @@ function StandingsSkeletonRow() {
 
 function StandingsSkeleton() {
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       <Skeleton className="h-10 w-full rounded-lg" />
-      <div className="bg-card rounded-lg border">
-        <div className="px-2 py-2 border-b border-border">
-          <div className="flex items-center justify-between">
-            <Skeleton className="h-4 w-20" />
-            <div className="flex space-x-6">
-              <Skeleton className="h-4 w-8" />
-              <Skeleton className="h-4 w-8" />
-              <Skeleton className="h-4 w-12" />
-              <Skeleton className="h-4 w-8" />
-            </div>
+      <div className="overflow-hidden rounded-xl border border-border bg-card">
+        <div className="flex items-center justify-between border-b border-border bg-muted/40 px-2.5 py-2">
+          <Skeleton className="h-4 w-24" />
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-6" />
+            <Skeleton className="h-4 w-6" />
+            <Skeleton className="h-4 w-10" />
+            <Skeleton className="h-4 w-6" />
           </div>
         </div>
-        <div className="space-y-0">
+        <div className="divide-y divide-border/50">
           {Array.from({ length: 15 }).map((_, i) => (
             <StandingsSkeletonRow key={i} />
           ))}
         </div>
       </div>
+    </div>
+  );
+}
+
+function Legend() {
+  return (
+    <div className="flex items-center justify-center gap-4 text-[10px] font-medium text-muted-foreground">
+      <span className="flex items-center gap-1.5">
+        <span className="h-2 w-2 rounded-full bg-playoff" />
+        Playoff
+      </span>
+      <span className="flex items-center gap-1.5">
+        <span className="h-2 w-2 rounded-full bg-playin" />
+        Play-In
+      </span>
     </div>
   );
 }
@@ -66,15 +79,15 @@ export default function StandingsList() {
 
   if (error) {
     return (
-      <div className="py-8 text-center space-y-4">
-        <div className="flex items-center justify-center text-destructive mb-2">
-          <AlertCircle className="h-6 w-6 mr-2" />
-          <span className="font-semibold">Failed to load standings</span>
+      <div className="py-10 text-center space-y-3">
+        <div className="mx-auto grid h-12 w-12 place-items-center rounded-full bg-destructive/10 text-destructive">
+          <AlertCircle className="h-6 w-6" />
         </div>
+        <span className="block font-semibold">Failed to load standings</span>
         <p className="text-muted-foreground text-sm">
           Check your internet connection or try again later
         </p>
-        <Button onClick={handleRefresh} variant="outline" className="mt-4">
+        <Button onClick={handleRefresh} variant="outline" size="sm" className="mt-2">
           <RefreshCw className="h-4 w-4 mr-2" />
           Try Again
         </Button>
@@ -84,12 +97,14 @@ export default function StandingsList() {
 
   if (!standings || !standings.conferences.length) {
     return (
-      <div className="text-center py-12">
-        <div className="text-6xl mb-4">🏆</div>
-        <h3 className="text-lg font-semibold text-foreground mb-2">
+      <div className="flex flex-col items-center justify-center py-14 text-center">
+        <div className="grid h-16 w-16 place-items-center rounded-2xl bg-muted/60 ring-1 ring-border/60">
+          <Trophy className="h-7 w-7 text-muted-foreground" />
+        </div>
+        <h3 className="mt-4 text-base font-semibold text-foreground">
           No standings available
         </h3>
-        <p className="text-muted-foreground">
+        <p className="mt-1 text-sm text-muted-foreground">
           Standings data is currently unavailable
         </p>
       </div>
@@ -97,19 +112,18 @@ export default function StandingsList() {
   }
 
   return (
-    <div className="space-y-2 w-full">
-      {/* Background refresh indicator */}
+    <div className="space-y-3 w-full">
       {isFetching && standings && (
-        <div className="flex items-center justify-center text-xs text-muted-foreground py-1">
-          <RefreshCw className="h-3 w-3 mr-1 animate-spin" />
+        <div className="flex items-center justify-center gap-1.5 text-[11px] font-medium text-muted-foreground py-1">
+          <RefreshCw className="h-3 w-3 animate-spin" />
           Updating standings...
         </div>
       )}
 
       <Tabs value={selectedConference} onValueChange={setSelectedConference} className="w-full">
         <TabsList className="grid w-full grid-cols-2">
-          <TabsTrigger value="eastern">Eastern Conference</TabsTrigger>
-          <TabsTrigger value="western">Western Conference</TabsTrigger>
+          <TabsTrigger value="eastern" className="text-xs font-semibold">Eastern</TabsTrigger>
+          <TabsTrigger value="western" className="text-xs font-semibold">Western</TabsTrigger>
         </TabsList>
 
         {standings.conferences.map((conference) => (
@@ -118,6 +132,8 @@ export default function StandingsList() {
           </TabsContent>
         ))}
       </Tabs>
+
+      <Legend />
     </div>
   );
 }

--- a/src/components/standings/TeamStandingRow.tsx
+++ b/src/components/standings/TeamStandingRow.tsx
@@ -1,7 +1,7 @@
 import { TeamStanding } from '../../types/game';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
-import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
+import { useFavoriteTeam } from '@/hooks/useFavoriteTeam';
 
 interface TeamStandingRowProps {
   teamStanding: TeamStanding;
@@ -10,8 +10,8 @@ interface TeamStandingRowProps {
 
 export default function TeamStandingRow({ teamStanding, rank }: TeamStandingRowProps) {
   const { team, stats, note } = teamStanding;
+  const { favoriteTeam } = useFavoriteTeam();
 
-  // Helper function to get stat value by name
   const getStatValue = (statName: string): string => {
     const stat = stats.find(s => s.name === statName);
     return stat?.displayValue || '0';
@@ -22,66 +22,68 @@ export default function TeamStandingRow({ teamStanding, rank }: TeamStandingRowP
   const winPercent = getStatValue('winPercent');
   const gamesBehind = getStatValue('gamesBehind');
 
-  // Determine if this team is in playoff position (top 8)
   const isPlayoffPosition = rank <= 8;
-
-  // Determine if this team is in play-in position (9-10)
   const isPlayInPosition = rank >= 9 && rank <= 10;
+  const isFavorite = favoriteTeam === team.id;
+
+  const zoneClass = isPlayoffPosition
+    ? 'border-l-playoff'
+    : isPlayInPosition
+    ? 'border-l-playin'
+    : 'border-l-transparent';
 
   return (
-    <div className={cn(
-      "flex items-center justify-between px-2 py-2 hover:bg-accent/20 transition-colors duration-200 group",
-      isPlayoffPosition && "bg-green-50/50 dark:bg-green-950/20",
-      isPlayInPosition && "bg-yellow-50/50 dark:bg-yellow-950/20"
-    )}>
-      <div className="flex items-center space-x-3 flex-1 min-w-0">
-        {/* Rank */}
-        <div className={cn(
-          "w-6 text-center text-sm font-semibold",
-          isPlayoffPosition && "text-green-600 dark:text-green-400",
-          isPlayInPosition && "text-yellow-600 dark:text-yellow-400"
-        )}>
+    <div
+      className={cn(
+        'flex items-center justify-between gap-2 border-l-2 px-2.5 py-2 transition-colors duration-200 group hover:bg-accent/40',
+        zoneClass,
+        isFavorite && 'bg-primary/5'
+      )}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-2.5">
+        {/* Rank chip */}
+        <div
+          className={cn(
+            'grid h-6 w-6 flex-shrink-0 place-items-center rounded-md text-xs font-bold tabular-nums',
+            isPlayoffPosition && 'bg-playoff/15 text-playoff',
+            isPlayInPosition && 'bg-playin/15 text-playin',
+            !isPlayoffPosition && !isPlayInPosition && 'bg-muted text-muted-foreground'
+          )}
+        >
           {rank}
         </div>
 
-        {/* Team Logo & Name */}
-        <div className="flex items-center space-x-2 min-w-0">
-          <Avatar className="h-7 w-7 border border-border flex-shrink-0">
-            <AvatarImage
-              src={team.logo}
-              alt={team.name}
-              className="object-contain p-1"
-            />
-            <AvatarFallback className="text-xs font-bold bg-muted">
-              {team.abbreviation}
-            </AvatarFallback>
+        {/* Team logo & name */}
+        <div className="flex min-w-0 items-center gap-2">
+          <Avatar className="h-7 w-7 flex-shrink-0 border border-border/60 bg-background/60">
+            <AvatarImage src={team.logo} alt={team.name} className="object-contain p-1" />
+            <AvatarFallback className="text-[9px] font-extrabold">{team.abbreviation}</AvatarFallback>
           </Avatar>
           <div className="min-w-0">
-            <div className="font-semibold text-sm truncate group-hover:text-primary transition-colors duration-200">
-              {team.name}
+            <div className="flex items-center gap-1.5">
+              <span className="truncate text-[13px] font-semibold leading-tight group-hover:text-primary transition-colors">
+                {team.name}
+              </span>
+              {isFavorite && <span className="text-[10px] text-primary">★</span>}
             </div>
             {note && (
-              <Badge
-                variant="outline"
-                className="mt-1 text-xs"
-                style={{
-                  borderColor: `#${note.color}`,
-                  color: `#${note.color}`
-                }}
+              <span
+                className="mt-0.5 inline-block text-[10px] font-medium leading-none"
+                style={{ color: `#${note.color}` }}
               >
                 {note.description}
-              </Badge>
+              </span>
             )}
           </div>
         </div>
       </div>
 
       {/* Stats */}
-      <div className="flex space-x-4 text-center text-sm">
+      <div className="flex items-center text-center text-sm tabular-nums">
         <div className="w-8 font-semibold">{wins}</div>
         <div className="w-8 font-semibold">{losses}</div>
-        <div className="w-12 font-medium">{winPercent}</div>
-        <div className="w-8 font-medium text-muted-foreground">{gamesBehind}</div>
+        <div className="w-12 font-bold">{winPercent}</div>
+        <div className="w-8 text-xs font-medium text-muted-foreground">{gamesBehind}</div>
       </div>
     </div>
   );

--- a/src/components/ui/badge-variants.ts
+++ b/src/components/ui/badge-variants.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority"
 
 export const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
@@ -11,11 +11,11 @@ export const badgeVariants = cva(
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
-        outline: "text-foreground",
-        live: "border-transparent bg-nba-live-500 text-white animate-live-pulse",
+        outline: "border-border text-foreground",
+        live: "border-transparent bg-live text-live-foreground",
         final: "border-transparent bg-muted text-muted-foreground",
-        scheduled: "border-transparent bg-nba-primary-100 text-nba-primary-800 dark:bg-nba-primary-900 dark:text-nba-primary-200",
-        record: "border-transparent bg-muted text-muted-foreground text-xs",
+        scheduled: "border-transparent bg-primary/10 text-primary dark:bg-primary/20",
+        record: "border-transparent bg-muted text-muted-foreground text-[10px] font-semibold normal-case tracking-normal",
       },
     },
     defaultVariants: {

--- a/src/components/ui/button-variants.ts
+++ b/src/components/ui/button-variants.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority"
 
 export const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
@@ -15,13 +15,14 @@ export const buttonVariants = cva(
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
         nba: "bg-nba-primary-600 text-white hover:bg-nba-primary-700 dark:bg-nba-primary-500 dark:hover:bg-nba-primary-600",
-        live: "bg-nba-live-500 text-white hover:bg-nba-live-600 animate-live-pulse",
+        live: "bg-live text-live-foreground hover:bg-live/90",
       },
       size: {
         default: "h-10 px-4 py-2",
         sm: "h-9 rounded-md px-3",
         lg: "h-11 rounded-md px-8",
         icon: "h-10 w-10",
+        xs: "h-7 rounded-md px-2 text-xs",
       },
     },
     defaultVariants: {

--- a/src/components/ui/card-variants.ts
+++ b/src/components/ui/card-variants.ts
@@ -1,20 +1,21 @@
 import { cva } from "class-variance-authority"
 
 export const cardVariants = cva(
-  "rounded-lg border bg-card text-card-foreground shadow-sm transition-all duration-200",
+  "rounded-xl border bg-card text-card-foreground shadow-card transition-all duration-200",
   {
     variants: {
       variant: {
         default: "border-border",
-        game: "border-border hover:bg-accent/30 hover:border-primary/40 transition-colors duration-200",
-        live: "border-nba-live-200 bg-nba-live-50 dark:border-nba-live-800 dark:bg-nba-live-950/20",
-        final: "border-muted bg-muted/30",
+        game: "border-border hover:bg-elevated hover:border-primary/40 hover:shadow-card-hover",
+        live: "border-live/40 bg-card live-glow animate-live-glow",
+        final: "border-border/60 bg-muted/20",
+        elevated: "border-border bg-elevated",
       },
       size: {
         default: "p-3",
         sm: "p-3",
         lg: "p-8",
-        game: "p-4",
+        game: "p-0",
       },
     },
     defaultVariants: {

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      "inline-flex h-10 items-center justify-center rounded-lg bg-muted/70 p-1 text-muted-foreground",
       className
     )}
     {...props}
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "relative inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm data-[state=inactive]:text-muted-foreground hover:data-[state=inactive]:text-foreground/80",
       className
     )}
     {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -1,52 +1,99 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    /* Light theme — clean & airy, tuned to match the bold dark identity */
+    --background: 210 40% 98%;
+    --foreground: 222 47% 11%;
+
+    /* Layered surfaces */
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 222 47% 11%;
+    --elevated: 0 0% 100%;
+    --elevated-foreground: 222 47% 11%;
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 221.2 83.2% 53.3%;
+    --popover-foreground: 222 47% 11%;
+
+    /* Bold NBA primary — a confident, energetic blue */
+    --primary: 222 89% 55%;
     --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96%;
-    --secondary-foreground: 222.2 84% 4.9%;
-    --muted: 210 40% 96%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96%;
-    --accent-foreground: 222.2 84% 4.9%;
-    --destructive: 0 84.2% 60.2%;
+    --primary-foreground-strong: 0 0% 100%;
+
+    /* Live accent — vivid red, tuned for visibility on both themes */
+    --live: 0 84% 58%;
+    --live-foreground: 0 0% 100%;
+    --live-glow: 0 84% 58%;
+
+    --secondary: 210 40% 94%;
+    --secondary-foreground: 222 47% 11%;
+    --muted: 214 32% 95%;
+    --muted-foreground: 215 16% 42%;
+    --accent: 210 40% 94%;
+    --accent-foreground: 222 47% 11%;
+    --destructive: 0 72% 51%;
     --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 221.2 83.2% 53.3%;
-    --radius: 0.75rem;
+
+    /* Standings zones */
+    --playoff: 142 71% 45%;
+    --playoff-foreground: 0 0% 100%;
+    --playin: 35 92% 55%;
+    --playin-foreground: 30 50% 12%;
+
+    --border: 214 32% 89%;
+    --input: 214 32% 89%;
+    --ring: 222 89% 55%;
+    --radius: 0.875rem;
+
+    /* Surfaces with transparency for overlays */
+    --surface-tint: 0 0% 100%;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
+    /* Dark-first: deep navy/charcoal with layered elevation so cards lift off */
+    --background: 224 47% 7%;
     --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
+
+    /* Raised card surface (subtle lift from background) */
+    --card: 222 44% 11%;
     --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
+    /* Higher elevation for hover / popovers */
+    --elevated: 222 40% 14%;
+    --elevated-foreground: 210 40% 98%;
+    --popover: 222 40% 13%;
     --popover-foreground: 210 40% 98%;
-    --primary: 217.2 91.2% 59.8%;
-    --primary-foreground: 222.2 84% 4.9%;
-    --secondary: 217.2 32.6% 17.5%;
+
+    /* Bold NBA primary — brighter blue that pops on dark */
+    --primary: 217 91% 60%;
+    --primary-foreground: 222 47% 11%;
+    --primary-foreground-strong: 210 40% 98%;
+
+    /* Live accent — luminous red with a warm glow */
+    --live: 0 90% 62%;
+    --live-foreground: 0 0% 100%;
+    --live-glow: 0 90% 62%;
+
+    --secondary: 222 40% 16%;
     --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
+    --muted: 222 38% 16%;
+    --muted-foreground: 215 20% 62%;
+    --accent: 222 40% 18%;
     --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
+    --destructive: 0 72% 51%;
     --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 224.3 76.3% 94.1%;
+
+    --playoff: 142 65% 52%;
+    --playoff-foreground: 0 0% 100%;
+    --playin: 38 95% 60%;
+    --playin-foreground: 30 50% 12%;
+
+    --border: 222 34% 18%;
+    --input: 222 34% 18%;
+    --ring: 217 91% 60%;
+
+    --surface-tint: 217 91% 60%;
   }
 
   * {
@@ -69,16 +116,25 @@
     -moz-osx-font-smoothing: grayscale;
     background-color: hsl(var(--background));
     color: hsl(var(--foreground));
+    /* Smooth theme transition */
+    transition: background-color 0.25s ease, color 0.25s ease;
   }
 
   #root {
     background-color: hsl(var(--background));
   }
+
+  /* Tabular figures for scores & stats */
+  .tabular-nums {
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: "tnum";
+  }
 }
 
 @layer components {
   .scrollbar-thin::-webkit-scrollbar {
-    width: 4px;
+    width: 6px;
+    height: 6px;
   }
 
   .scrollbar-thin::-webkit-scrollbar-track {
@@ -86,11 +142,27 @@
   }
 
   .scrollbar-thin::-webkit-scrollbar-thumb {
-    background: rgb(156 163 175);
-    border-radius: 2px;
+    background: hsl(var(--muted-foreground) / 0.35);
+    border-radius: 9999px;
   }
 
   .scrollbar-thin::-webkit-scrollbar-thumb:hover {
-    background: rgb(107 114 128);
+    background: hsl(var(--muted-foreground) / 0.6);
+  }
+
+  /* Subtle ambient background tint behind the app */
+  .app-ambient {
+    background-image:
+      radial-gradient(ellipse 80% 50% at 50% -10%, hsl(var(--surface-tint) / 0.06), transparent 70%);
+  }
+}
+
+@layer utilities {
+  /* Live card glow ring */
+  .live-glow {
+    box-shadow: 0 0 0 1px hsl(var(--live) / 0.5), 0 0 22px -2px hsl(var(--live-glow) / 0.35);
+  }
+  .text-balance {
+    text-wrap: balance;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -49,6 +49,23 @@ export default {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        elevated: {
+          DEFAULT: "hsl(var(--elevated))",
+          foreground: "hsl(var(--elevated-foreground))",
+        },
+        live: {
+          DEFAULT: "hsl(var(--live))",
+          foreground: "hsl(var(--live-foreground))",
+          glow: "hsl(var(--live-glow))",
+        },
+        playoff: {
+          DEFAULT: "hsl(var(--playoff))",
+          foreground: "hsl(var(--playoff-foreground))",
+        },
+        playin: {
+          DEFAULT: "hsl(var(--playin))",
+          foreground: "hsl(var(--playin-foreground))",
+        },
         nba: {
           primary: {
             50: '#eff6ff',
@@ -103,6 +120,12 @@ export default {
           "sans-serif",
         ],
       },
+      boxShadow: {
+        card: "0 1px 2px hsl(var(--foreground) / 0.04), 0 4px 12px -2px hsl(var(--foreground) / 0.06)",
+        "card-hover": "0 2px 4px hsl(var(--foreground) / 0.06), 0 10px 28px -4px hsl(var(--foreground) / 0.12)",
+        live: "0 0 0 1px hsl(var(--live) / 0.4), 0 8px 24px -6px hsl(var(--live-glow) / 0.45)",
+        header: "0 1px 0 hsl(var(--foreground) / 0.05), 0 8px 24px -12px hsl(var(--foreground) / 0.4)",
+      },
       keyframes: {
         "accordion-down": {
           from: { height: "0" },
@@ -114,7 +137,11 @@ export default {
         },
         "live-pulse": {
           "0%, 100%": { opacity: "1" },
-          "50%": { opacity: "0.5" },
+          "50%": { opacity: "0.55" },
+        },
+        "live-glow": {
+          "0%, 100%": { boxShadow: "0 0 0 1px hsl(var(--live) / 0.45), 0 6px 20px -8px hsl(var(--live-glow) / 0.4)" },
+          "50%": { boxShadow: "0 0 0 1px hsl(var(--live) / 0.65), 0 10px 32px -4px hsl(var(--live-glow) / 0.65)" },
         },
         "slide-in": {
           from: { transform: "translateX(-100%)" },
@@ -123,14 +150,23 @@ export default {
         "fade-in": {
           from: { opacity: "0" },
           to: { opacity: "1" },
-        }
+        },
+        "slide-up-fade": {
+          from: { opacity: "0", transform: "translateY(8px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
+        "shimmer": {
+          "100%": { transform: "translateX(100%)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
-        "live-pulse": "live-pulse 2s ease-in-out infinite",
+        "live-pulse": "live-pulse 1.8s ease-in-out infinite",
+        "live-glow": "live-glow 2.4s ease-in-out infinite",
         "slide-in": "slide-in 0.3s ease-out",
         "fade-in": "fade-in 0.2s ease-out",
+        "slide-up-fade": "slide-up-fade 0.32s cubic-bezier(0.22, 1, 0.36, 1) both",
       },
     },
   },


### PR DESCRIPTION
## Summary

A comprehensive UI redesign of the NBA Scores extension, structured in three layered commits that each build on the previous.

### Commits

**1. Design token system** (`index.css`, `tailwind.config.js`)
- Reworked light/dark CSS variables for layered surfaces (card, elevated, popover) and a bolder NBA primary blue
- Added `live`, `playoff`, and `play-in` accent tokens with foreground/glow variants
- Custom box-shadow scale (card, card-hover, live, header), `live-glow` utility, and new keyframes (live-glow, slide-up-fade, shimmer)
- `tabular-nums` utility, ambient background tint, smooth theme transition

**2. UI primitives** (`components/ui/*`)
- Badge, button, card, and tabs variants updated to consume the new tokens

**3. Component redesign** (common, scores, settings, standings + `popup.html`)
- Elevated gradient header with ambient highlight and pill tabs
- GameCard with team-color accent strip, stacked rows, live glow, motion entrance
- GamePreview with elevated cards, team-color headers, sticky player table
- Scores grid 3 → 2 columns; refined skeletons/empty/error states
- DateCarousel compact day chips with today indicator
- Standings with playoff/play-in zone chips, favorite highlight, and legend
- Replaced `Button` usages with lightweight native buttons where appropriate
- Widened popup to 540px for the new 2-column grid

## Verification

- `npm run type-check` ✅
- `npm run lint` ✅ (zero warnings)
- `npm run build` ✅

## Notes

- Dark theme is applied automatically when the system theme is dark.
- True extension-context testing (chrome.storage, CSP, cross-origin ESPN calls) requires loading `dist/` as an unpacked extension; the browser preview cannot fully exercise those.